### PR TITLE
dependabot: use default labels, shorter message prefix, monthly cargo update intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "deps(cargo):"
     open-pull-requests-limit: 4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps/cargo):"
-    labels:
-      - "t-dependencies"
-      - "pkg-cargo"
+      prefix: "deps(cargo):"
     open-pull-requests-limit: 4
 
   - package-ecosystem: "github-actions"
@@ -21,8 +18,5 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps/actions):"
-    labels:
-      - "t-dependencies"
-      - "pkg-gh-actions"
+      prefix: "deps(gha):"
     open-pull-requests-limit: 4


### PR DESCRIPTION
- These custom labels aren't auto-generated and have to be re-created by whoever uses the template. Instead, use the default labels that Dependabot provides.
- Use a shorter prefix in commit messages to fit more text
- Make cargo dependencies update on monthly interval (longest interval) by default, to help mitigate against PR fatigue