### PR TITLE
chore: render tabs as 4 spaces instead of 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
-indent_tab = 8
+indent_tab = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,2 @@
 hard_tabs = true
-tab_spaces = 8
+tab_spaces = 4


### PR DESCRIPTION
A personal opinion of my own; 4 is a nice balance between rendering tabs as 2 spaces vs 8 spaces. This updates both Rustfmt (.rustfmt.toml) and EditorConfig (.editorconfig)