### PR TITLE
chore: use Rust 2024 edition + workspace inheritance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         include:
           - label: msrv
-            toolchain: '1.76'
+            toolchain: '1.88'
           - label: stable
             toolchain: stable
           - label: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 members = ["crates/*"]
-resolver = "2"
+resolver = "3"
+
+[workspace.package]
+authors = ["{{author}} <{{email}}>"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.88.0"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/my-crate/Cargo.toml
+++ b/crates/my-crate/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "my-crate"
 version = "0.1.0"
-authors = ["{{author}} <{{email}}>"]
 description = "{{desc}}"
-readme = "README.md"
-license = "MIT OR Apache-2.0"
-
-edition = "2021"
-rust-version = "1.76.0"
-
+include = ["src", "LICENSE*"]
 keywords = []
 categories = []
-
-include = ["src", "LICENSE*"]
+readme = "README.md"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true


### PR DESCRIPTION
- use 2024 edition
- bump workspace resolver from v2 to v3
- bump minimum supported rust version from v1.76 to v1.88